### PR TITLE
chore(a11y): wrap content in landmarks + Add Playwright+axe tests and CI

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,35 @@
+name: Accessibility tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  a11y:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers and system deps
+        run: npx playwright install --with-deps
+
+      - name: Run accessibility tests
+        run: npx playwright test a11y-region.spec.js --reporter=junit
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report

--- a/a11y-region.spec.js
+++ b/a11y-region.spec.js
@@ -1,0 +1,62 @@
+// Basic Playwright test to check for axe region landmark violation
+// Requires: @playwright/test, axe-core/playwright
+
+const { test, expect } = require('@playwright/test');
+const { injectAxe, checkA11y } = require('axe-playwright');
+
+test.describe('Accessibility', () => {
+  const path = require('path');
+  const fileUrl = 'file://' + path.resolve(__dirname, 'index.html');
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(fileUrl);
+    await injectAxe(page);
+  });
+
+  test('All content is contained by landmarks (region rule)', async ({ page }) => {
+    await checkA11y(page, null, {
+      runOnly: ['region'],
+      detailedReport: true,
+      detailedReportOptions: { html: true },
+    });
+  });
+
+  test('Selected rules smoke test (image-alt, label, heading-order)', async ({ page }) => {
+    await checkA11y(page, null, {
+      runOnly: {
+        type: 'rule',
+        values: ['image-alt', 'label', 'heading-order']
+      },
+      detailedReport: true,
+      detailedReportOptions: { html: true },
+    });
+  });
+
+  test('Additional focused rules (contrast, title, link-name, duplicate-id, lang, meta-viewport, ARIA)', async ({ page }) => {
+    await checkA11y(page, null, {
+      runOnly: {
+        type: 'rule',
+        values: [
+          'color-contrast',
+          'document-title',
+          'link-name',
+          'duplicate-id',
+          'html-has-lang',
+          'meta-viewport',
+          'aria-allowed-attr',
+          'aria-valid-attr'
+        ]
+      },
+      detailedReport: true,
+      detailedReportOptions: { html: true },
+    });
+  });
+
+  test('Full page axe scan (all rules)', async ({ page }) => {
+    // Run a full page scan; this will fail the test if any violations are found.
+    await checkA11y(page, null, {
+      detailedReport: true,
+      detailedReportOptions: { html: true },
+    });
+  });
+});

--- a/index.html
+++ b/index.html
@@ -17,9 +17,10 @@
 	</head>
 
 	<body>
-		<main class="container">
-			
+		<header>
 			<h1 class="message">Find Your Perfect Home!</h1>
+		</header>
+		<main class="container">
 
 			<div class="enter-name">
 				<form id="name" name="name" action="buildJson.php" method="post">

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "underscore": "^1.9.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.56.0",
         "autoprefixer": "^10.4.21",
+        "axe-playwright": "^2.2.2",
         "browserify": "^13.3.0",
         "concurrently": "^9.2.1",
         "del": "^8.0.1",
@@ -496,6 +498,21 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.0.tgz",
+      "integrity": "sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
@@ -508,6 +525,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@types/junit-report-builder": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/junit-report-builder/-/junit-report-builder-3.0.2.tgz",
+      "integrity": "sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==",
+      "dev": true
     },
     "node_modules/acorn": {
       "version": "5.7.4",
@@ -1046,6 +1069,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
+      "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axe-html-reporter": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/axe-html-reporter/-/axe-html-reporter-2.2.11.tgz",
+      "integrity": "sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==",
+      "dev": true,
+      "dependencies": {
+        "mustache": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      },
+      "peerDependencies": {
+        "axe-core": ">=3"
+      }
+    },
+    "node_modules/axe-playwright": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/axe-playwright/-/axe-playwright-2.2.2.tgz",
+      "integrity": "sha512-h350/grzDCPgpuWV7eEOqr/f61Xn07Gi9f9B3Ew4rW6/nFtpdEJYW6jgRATorgAGXjEAYFTnaY3sEys39wDw4A==",
+      "dev": true,
+      "dependencies": {
+        "@types/junit-report-builder": "^3.0.2",
+        "axe-core": "^4.10.1",
+        "axe-html-reporter": "2.2.11",
+        "junit-report-builder": "^5.1.1",
+        "picocolors": "^1.1.1"
+      },
+      "peerDependencies": {
+        "playwright": ">1.0.0"
       }
     },
     "node_modules/babel-code-frame": {
@@ -6257,6 +6320,20 @@
         "node": "*"
       }
     },
+    "node_modules/junit-report-builder": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-5.1.1.tgz",
+      "integrity": "sha512-ZNOIIGMzqCGcHQEA2Q4rIQQ3Df6gSIfne+X9Rly9Bc2y55KxAZu8iGv+n2pP0bLf0XAOctJZgeloC54hWzCahQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "make-dir": "^3.1.0",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/just-debounce": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
@@ -6692,6 +6769,30 @@
       "license": "MIT",
       "dependencies": {
         "es5-ext": "~0.10.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -7210,6 +7311,15 @@
         "inherits": "~2.0.1",
         "isarray": "0.0.1",
         "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "bin": {
+        "mustache": "bin/mustache"
       }
     },
     "node_modules/mute-stdout": {
@@ -7995,6 +8105,50 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plugin-error": {
@@ -10631,6 +10785,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": " ",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+  "test": "echo \"Error: no test specified\" && exit 1",
+  "serve": "npx serve . -l 8080",
+  "a11y": "npx playwright test a11y-region.spec.js",
+  "a11y:serve": "npm run serve & npx playwright test a11y-region.spec.js",
+  "a11y:ci": "npx playwright test a11y-region.spec.js --reporter=list",
     "sass:dev": "sass --watch scss/styles.scss:css/styles.css --style=expanded --source-map",
     "sass:prod": "sass --watch scss/styles.scss:css/styles.min.css --style=compressed --no-source-map",
     "sass:watch": "concurrently \"npm run sass:dev\" \"npm run sass:prod\""
@@ -20,7 +24,9 @@
   },
   "homepage": "https://github.com/amyeckert/perfecthome-js#readme",
   "devDependencies": {
+    "@playwright/test": "^1.56.0",
     "autoprefixer": "^10.4.21",
+    "axe-playwright": "^2.2.2",
     "browserify": "^13.3.0",
     "concurrently": "^9.2.1",
     "del": "^8.0.1",

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
This PR fixes an axe 'region' accessibility violation by placing the page heading in a <header> landmark and ensuring main content is inside <main>. It also adds Playwright + axe tests (a11y-region.spec.js) and a GitHub Actions workflow to prevent regressions.\n\nChanges:\n- Wrap <h1> in <header> and keep rest inside <main>\n- Add Playwright+axe tests (region, selected rules, focused rules, full page)\n- Add npm scripts to run tests locally\n- Add GitHub Actions workflow to run tests on push/PR\n\nAssigning to @amyeckert for review.